### PR TITLE
fix bug, causing black kings being displayed as white kings

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlydame/game/Piece.java
+++ b/app/src/main/java/org/secuso/privacyfriendlydame/game/Piece.java
@@ -75,6 +75,6 @@ public class Piece implements Serializable {
      */
     void makeKing() {
         isKing = true;
-        summaryID += 2;
+        summaryID = color + 2;
     }
 }


### PR DESCRIPTION
The mitigated error was only visual. The game logic itself was not
faulty.

Explaination:

If a black piece traveled to the opposite end of the field, it will be
upgraded to a black king. In this form the piece is able to travel
backwards. The method of checking if a piece should be upgraded is
flawed. It assumes that pieces should be upgraded everytime it reaches
an edge. If any piece that is already a king visits an edge,
Piece.makeKing() will be called, causing summaryID to increment
further. Any value above 3 (black king) will cause the piece being
displayed as white king.

Reference:

CheckersLayout.animateMove() in the ui portion of the code